### PR TITLE
feat: restart failing controllers automatically with exp backoff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/AlekSi/pointer v1.1.0
+	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/hashicorp/go-memdb v1.3.0
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/AlekSi/pointer v1.1.0 h1:SSDMPcXD9jSl8FPy9cRzoRaMJtm9g9ggGTxecRUbQoI=
 github.com/AlekSi/pointer v1.1.0/go.mod h1:y7BvfRI3wXPWKXEBhU71nbnIEEZX0QTSB2Bj48UJIZE=
+github.com/cenkalti/backoff/v4 v4.1.0 h1:c8LkOFQTzuO0WBM/ae5HdGQuZPfPxp7lqBRwQRm4fSc=
+github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=

--- a/pkg/controller/runtime/runtime_test.go
+++ b/pkg/controller/runtime/runtime_test.go
@@ -259,6 +259,20 @@ func (suite *RuntimeSuite) TestSumControllers() {
 		Retry(suite.assertIntObjects("target", IntResourceType, []string{"sum"}, []int{2})))
 }
 
+func (suite *RuntimeSuite) TestFailingController() {
+	suite.Require().NoError(suite.runtime.RegisterController(&FailingController{
+		TargetNamespace: "target",
+	}))
+
+	suite.startRuntime()
+
+	suite.Assert().NoError(retry.Constant(5*time.Second, retry.WithUnits(10*time.Millisecond)).
+		Retry(suite.assertIntObjects("target", IntResourceType, []string{"0"}, []int{0})))
+
+	suite.Assert().NoError(retry.Constant(5*time.Second, retry.WithUnits(10*time.Millisecond)).
+		Retry(suite.assertIntObjects("target", IntResourceType, []string{"0", "1"}, []int{0, 1})))
+}
+
 func TestRuntime(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
On controller failure new reconcile event is scheduler and controller is
restarted with exponential backoff to prevent crash looping.

Errors and restarts are logged for easier debugging.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>