### PR TITLE
feat: sort resources returned from the List() API

### DIFF
--- a/pkg/state/conformance/state.go
+++ b/pkg/state/conformance/state.go
@@ -80,8 +80,6 @@ func (suite *StateSuite) TestCRD() {
 				ids[i] = list.Items[i].String()
 			}
 
-			sort.Strings(ids)
-
 			suite.Assert().Equal([]string{path2.String(), path1.String()}, ids)
 		} else {
 			suite.Assert().Len(list.Items, 1)

--- a/pkg/state/impl/inmem/collection.go
+++ b/pkg/state/impl/inmem/collection.go
@@ -6,6 +6,7 @@ package inmem
 
 import (
 	"context"
+	"sort"
 	"sync"
 
 	"github.com/talos-systems/os-runtime/pkg/resource"
@@ -75,7 +76,6 @@ func (collection *ResourceCollection) Get(resourceID resource.ID) (resource.Reso
 // List resources.
 func (collection *ResourceCollection) List() (resource.List, error) {
 	collection.mu.Lock()
-	defer collection.mu.Unlock()
 
 	result := resource.List{
 		Items: make([]resource.Resource, 0, len(collection.storage)),
@@ -84,6 +84,12 @@ func (collection *ResourceCollection) List() (resource.List, error) {
 	for _, res := range collection.storage {
 		result.Items = append(result.Items, res.DeepCopy())
 	}
+
+	collection.mu.Unlock()
+
+	sort.Slice(result.Items, func(i, j int) bool {
+		return result.Items[i].Metadata().ID() < result.Items[j].Metadata().ID()
+	})
 
 	return result, nil
 }


### PR DESCRIPTION
This fixes user-facing `talosctl get <resource>`, and also provides
stable order for controllers listing other resources.

This also aligns with the way etcd API works (returns sorted keys).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>