### PR TITLE
feat: add an option to bootstrap WatchKind with initial list of resources

### DIFF
--- a/pkg/state/impl/inmem/inmem.go
+++ b/pkg/state/impl/inmem/inmem.go
@@ -69,6 +69,6 @@ func (state *State) Watch(ctx context.Context, resourcePointer resource.Pointer,
 }
 
 // WatchKind all resources by type.
-func (state *State) WatchKind(ctx context.Context, resourceKind resource.Kind, ch chan<- state.Event) error {
-	return state.getCollection(resourceKind.Type()).WatchAll(ctx, ch)
+func (state *State) WatchKind(ctx context.Context, resourceKind resource.Kind, ch chan<- state.Event, opts ...state.WatchKindOption) error {
+	return state.getCollection(resourceKind.Type()).WatchAll(ctx, ch, opts...)
 }

--- a/pkg/state/impl/namespaced/namespaced.go
+++ b/pkg/state/impl/namespaced/namespaced.go
@@ -86,6 +86,6 @@ func (st *State) Watch(ctx context.Context, ptr resource.Pointer, ch chan<- stat
 }
 
 // WatchKind watches resources of specific kind (namespace and type).
-func (st *State) WatchKind(ctx context.Context, kind resource.Kind, ch chan<- state.Event) error {
-	return st.getNamespace(kind.Namespace()).WatchKind(ctx, kind, ch)
+func (st *State) WatchKind(ctx context.Context, kind resource.Kind, ch chan<- state.Event, opts ...state.WatchKindOption) error {
+	return st.getNamespace(kind.Namespace()).WatchKind(ctx, kind, ch, opts...)
 }

--- a/pkg/state/options.go
+++ b/pkg/state/options.go
@@ -45,3 +45,18 @@ type WatchOptions struct{}
 
 // WatchOption builds WatchOptions.
 type WatchOption func(*WatchOptions)
+
+// WatchKindOptions for the CoreState.WatchKind function.
+type WatchKindOptions struct {
+	BootstrapContents bool
+}
+
+// WatchKindOption builds WatchOptions.
+type WatchKindOption func(*WatchKindOptions)
+
+// WithBootstrapContents enables loading initial list of resources as 'created' events for WatchKind API.
+func WithBootstrapContents(enable bool) WatchKindOption {
+	return func(opts *WatchKindOptions) {
+		opts.BootstrapContents = enable
+	}
+}

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -70,7 +70,7 @@ type CoreState interface {
 	Watch(context.Context, resource.Pointer, chan<- Event, ...WatchOption) error
 
 	// WatchKind watches resources of specific kind (namespace and type).
-	WatchKind(context.Context, resource.Kind, chan<- Event) error
+	WatchKind(context.Context, resource.Kind, chan<- Event, ...WatchKindOption) error
 }
 
 // UpdaterFunc is called on resource to update it to the desired state.


### PR DESCRIPTION
This allows to have a consistent view of a list of resources, it is
bootstrapped with the initial list and then incremental updates.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>