### PR TITLE
chore: provide fmt.Stringer for EventType

### DIFF
--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -24,6 +24,10 @@ const (
 	Destroyed
 )
 
+func (eventType EventType) String() string {
+	return [...]string{"Created", "Updated", "Destroyed"}[eventType]
+}
+
 // Event is emitted when resource changes.
 type Event struct {
 	Type     EventType


### PR DESCRIPTION
Simple fix to allow easier printing of events.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>