### PR TITLE
feat: use go-yaml fork and serialize spec as RawYAML objects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/talos-systems/os-runtime
 
 go 1.14
 
+// forked yaml that introduces RawYAML interface that can be used to provide YAML encoder bytes
+// which are then encoded as a valid YAML block with proper indentiation
+replace gopkg.in/yaml.v3 => github.com/unix4ever/yaml v0.0.0-20210315173758-8fb30b8e5a5b
+
 require (
 	github.com/AlekSi/pointer v1.1.0
 	github.com/cenkalti/backoff/v4 v4.1.0

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/talos-systems/go-retry v0.2.0 h1:YpQHmtTZ2k0i/bBYRIasdVmF0XaiISVJUOrmZ6FzgLU=
 github.com/talos-systems/go-retry v0.2.0/go.mod h1:HiXQqyVStZ35uSY/MTLWVvQVmC3lIW2MS5VdDaMtoKM=
+github.com/unix4ever/yaml v0.0.0-20210315173758-8fb30b8e5a5b h1:8pnPjZJU0SYanlmHnhMTeR8OR148K9yStwBz1GsjBsQ=
+github.com/unix4ever/yaml v0.0.0-20210315173758-8fb30b8e5a5b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -45,10 +47,7 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11 h1:Yq9t9jnGoR+dBuitxdo9l6Q7xh/zOyNnYUtDKaQ3x0E=
 golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/resource/any.go
+++ b/pkg/resource/any.go
@@ -18,12 +18,12 @@ type Any struct {
 
 type anySpec struct {
 	value interface{}
-	doc   yaml.Node
 	yaml  []byte
 }
 
-func (s anySpec) MarshalYAML() (interface{}, error) {
-	return s.doc.Content[0], nil
+// MarshalYAMLBytes implements RawYAML interface.
+func (s anySpec) MarshalYAMLBytes() ([]byte, error) {
+	return s.yaml, nil
 }
 
 // SpecProto is a protobuf interface of resource spec.
@@ -46,10 +46,6 @@ func NewAnyFromProto(protoMd MetadataProto, protoSpec SpecProto) (*Any, error) {
 	}
 
 	if err = yaml.Unmarshal(any.spec.yaml, &any.spec.value); err != nil {
-		return nil, err
-	}
-
-	if err = yaml.Unmarshal(any.spec.yaml, &any.spec.doc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/resource/any_test.go
+++ b/pkg/resource/any_test.go
@@ -49,8 +49,8 @@ metadata:
     version: 1
     phase: running
     finalizers:
-      - resource1
-      - resource2
+        - resource1
+        - resource2
 spec:
     value: xyz
     something: [a, b, c]

--- a/pkg/resource/metadata_test.go
+++ b/pkg/resource/metadata_test.go
@@ -99,8 +99,8 @@ id: aaa
 version: 1
 phase: running
 finalizers:
-  - '"resource1'
-  - resource2
+    - '"resource1'
+    - resource2
 `, string(out))
 }
 


### PR DESCRIPTION
This should address incorrect comment indents as we're going to write
the spec as a raw YAML block.

Signed-off-by: Artem Chernyshev <artem.0xD2@gmail.com>